### PR TITLE
Add grubby to Requires

### DIFF
--- a/SPECS/xcp-ng-deps.spec
+++ b/SPECS/xcp-ng-deps.spec
@@ -1,6 +1,6 @@
 Name:           xcp-ng-deps
 Version:        8.3
-Release:        3
+Release:        4
 Summary:        A meta package pulling all needed dependencies for XCP-ng
 # License covers this spec file
 License:        GPLv2
@@ -136,6 +136,9 @@ Requires: zip
 # XAPI chokes on nvidia GPUs without that package
 Requires: gpumon
 
+# host-installer needs this to be installed
+Requires: grubby
+
 Requires(post): sed
 
 # Additional niceties
@@ -211,6 +214,9 @@ fi
 %files
 
 %changelog
+* Wed Feb 15 2023 Yann Dirson <yann.dirson@vates.fr> - 8.3-4
+- Requires grubby
+
 * Tue Dec 08 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 8.3-3
 - Remove and obsolete linux-guest-loader and linux-guest-loader-data
 


### PR DESCRIPTION
It was previously only pulled by memtest86+, but host-installer requires it in the system it is installing.

Primary cause of https://xcp-ng.org/forum/topic/5652/panic-on-cpu-0-xen-bug-at-iommu-init-c-1419
