### PR TITLE
Force selection of libverto-tevent

### DIFF
--- a/SPECS/xcp-ng-deps.spec
+++ b/SPECS/xcp-ng-deps.spec
@@ -1,6 +1,6 @@
 Name:           xcp-ng-deps
 Version:        8.3
-Release:        6
+Release:        7
 Summary:        A meta package pulling all needed dependencies for XCP-ng
 # License covers this spec file
 License:        GPLv2
@@ -147,6 +147,11 @@ Requires: htop
 Requires: iftop
 Requires: yum-utils
 
+# Default provider of libverto-module-base in CentOS 7, to ensure
+# reproducibility of the nfs-utils -> gssproxy -> libverto-module-base
+# chain, which is too weak
+Requires: libverto-tevent
+
 # Obsolete package to be removed during upgrade to 7.5 or higher
 Obsoletes: vgpu < 7.3.3
 
@@ -220,6 +225,9 @@ fi
 %files
 
 %changelog
+* Mon Sep 18 2023 Yann Dirson <yann.dirson@vates.fr> - 8.3-7
+- Add libverto-tevent as explicit require
+
 * Thu Sep 14 2023 Thierry Escande <thierry.escande@vates.tech> - 8.3-6
 - Requires xo-lite
 


### PR DESCRIPTION
The only known libverto user in XCP-ng dom0 is gssproxy, whose code does not care about which libverto backend will be used, so the choice of which one to use is delegated at runtime to libverto.

libverto has a "default backend" configured, which will be used it available, and this is libverto-tevent in this version.  Having this package installed is the only way to ensure the same lib will be used by gssproxy (and any other similar software, if any), regardless of whether libverto-libevent is also installed.

This is still not perfect, as having libverto-glib installed apparently causes libverto-tevent (for some reason) to also load libglib.so, but should be good enough as no supported package uses the latter.